### PR TITLE
Clean YouTube sharing links

### DIFF
--- a/share/metadata.py
+++ b/share/metadata.py
@@ -13,7 +13,7 @@
 
 __name__="ezdl"
 __namespace__="ezdl"
-__version__="0.2.5"
+__version__="0.2.6"
 __description__="Video downloader script for YouTube, Instagram, Tik Tok, and more."
 __author__="irfanhakim"
 __author_email__="irfanhakim.as@yahoo.com"

--- a/share/parser.py
+++ b/share/parser.py
@@ -20,6 +20,6 @@ def sanitiseVideoList(videoList):
     videoList = ["https://player.vimeo.com/video/%s" % re.search(r'vimeo\.com/(\d+)', l).group(1) if l.startswith("https://vimeo.com") else l for l in videoList]
     # reformat xitter links
     videoList = [l.replace("x.com/", "twitter.com/").strip().rstrip("/") if l.startswith("https://x.com") else l for l in videoList]
-    # clean instagram links
-    videoList = [l.split("?")[0].strip().rstrip("/") if "instagram.com" in l else l for l in videoList]
+    # clean tracking links
+    videoList = [l.split("?")[0].strip().rstrip("/") if any(domain in l for domain in ("instagram.com", "youtu.be")) else l for l in videoList]
     return videoList


### PR DESCRIPTION
# Changes

- Updated previous cleaning of tracking links for `instagram.com` to also include `youtu.be` links
- Upgraded app version to `0.2.6`